### PR TITLE
Fix iOS linking errors by bumping minimum Swift version to 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2
 import PackageDescription
 
 let name = "LegibleError"
@@ -11,5 +11,6 @@ let package = Package(
     targets: [
         .target(name: name, path: "Sources"),
         .testTarget(name: "LegibleErrorTests", dependencies: [.init(stringLiteral: name)]),
-    ]
+    ],
+    swiftLanguageVersions: [.v4, .v4_2, .version("5")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let name = "LegibleError"
@@ -11,6 +11,5 @@ let package = Package(
     targets: [
         .target(name: name, path: "Sources"),
         .testTarget(name: "LegibleErrorTests", dependencies: [.init(stringLiteral: name)]),
-    ],
-    swiftLanguageVersions: [.v4, .v4_2, .version("5")]
+    ]
 )

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let name = "LegibleError"
+
+let package = Package(
+    name: name,
+    products: [
+        .library(name: name, targets: [name]),
+    ],
+    targets: [
+        .target(name: name, path: "Sources"),
+        .testTarget(name: "LegibleErrorTests", dependencies: [.init(stringLiteral: name)]),
+    ]
+)


### PR DESCRIPTION
I've come across some [iOS linking errors](https://github.com/rythmico/FoundationEncore/runs/4056275541?check_suite_focus=true) produced by this package.

The [working solution](https://github.com/rythmico/FoundationEncore/pull/5) was forking this repo and dropping Swift 4.x support.

I'd say Swift 4 is probably old enough to consider dropping support on upstream too. This is why I made this PR.

It's up to you though, of course.